### PR TITLE
Replace zefyr with a forked repository

### DIFF
--- a/mod-doc/client/Makefile
+++ b/mod-doc/client/Makefile
@@ -3,7 +3,7 @@
 # https://github.com/memspace/zefyr
 
 LIB_NAME=zefyr
-LIB=github.com/memspace/$(LIB_NAME)
+LIB=github.com/winwisely112/$(LIB_NAME)
 LIB_BRANCH=master
 LIB_FSPATH=$(GOPATH)/src/$(LIB)
 
@@ -76,7 +76,7 @@ flu-desk-local-run: ## flu-desk-local-run
 
 flu-desk-local-build: ## flu-desk-local-build
 	# does not use docker
-	cd $(SAMPLE_FSPATH) && hover build
+	cd $(SAMPLE_FSPATH) && hover build 
 
 
 flu-desk-build-all: ## flu-desk-build-all

--- a/mod-doc/client/README.md
+++ b/mod-doc/client/README.md
@@ -1,0 +1,2 @@
+We temporarily use a fork of zefyr, because it has some issues with flutter's beta channel:
+[https://github.com/winwisely112/zefyr](https://github.com/winwisely112/zefyr)


### PR DESCRIPTION
Replaces zefyr with a forked repository, because zefyr has some issues with beta channel of Flutter.