### PR TITLE
PACKAGES: maintemplate updated flutter modular version to fix initial…

### DIFF
--- a/maintemplate/client/pubspec.yaml
+++ b/maintemplate/client/pubspec.yaml
@@ -58,7 +58,7 @@ dependencies:
   get_it: ^3.1.0
   equatable:
   meta:
-  flutter_modular: ^0.5.2
+  flutter_modular: ^0.5.5
   #font_awesome_flutter:
 
   cupertino_icons: ^0.1.2


### PR DESCRIPTION
Works for all dependencies (packages, mod-XXX), as their pubspec flutter modular notation is e.g. "^0.5.5"
So conflict resolution leads to 0.5.5 right now, which has the fix!
(Working on master now)