### PR TITLE
#332 Adding urlNative call to chat_service

### DIFF
--- a/mod-chat/client/lib/grpc_web_example/api/chat_service.dart
+++ b/mod-chat/client/lib/grpc_web_example/api/chat_service.dart
@@ -180,7 +180,7 @@ class ChatService {
     //wait for host url and then go on!
     await for (var message in newReceivePort){
       if (message is ChatModuleConfig) {
-        hostUrl = message.url;
+        hostUrl = message.urlNative;
         break;
       }
     }


### PR DESCRIPTION
#332 So, this final change technically fulfills the requirements of the ticket, but the chat is still broken:

flutter: Failed to send message "[#73567]" to the server: gRPC Error (14, Error connecting: SocketException: OS Error: Connection timed out, errno = 110, address = grpc.maintemplate.ci.getcouragenow.org, port = 33000)
flutter: Failed to receive messages from the server: gRPC Error (14, Error connecting: SocketException: OS Error: Connection timed out, errno = 110, address = grpc.maintemplate.ci.getcouragenow.org, port = 33006)