### PR TITLE
Issue #368 - Pulling Data into mod-main

### DIFF
--- a/mod-chat/server/cmd/client.go
+++ b/mod-chat/server/cmd/client.go
@@ -68,6 +68,7 @@ func main() {
 
 	id := sha256.Sum256([]byte(timestamp.String() + *name))
 
+	// TODO: Add environment vars from top
 	tlsCert, _, err := getcert.FromTLSServer("grpc.maintemplate.ci.getcouragenow.org:443", false)
 
 	config := &tls.Config{

--- a/mod-main/server/Makefile
+++ b/mod-main/server/Makefile
@@ -1,0 +1,54 @@
+.DEFAULT_GOAL       := help
+VERSION             := v0.0.0
+TARGET_MAX_CHAR_NUM := 20
+
+GREEN  := $(shell tput -Txterm setaf 2)
+YELLOW := $(shell tput -Txterm setaf 3)
+WHITE  := $(shell tput -Txterm setaf 7)
+RESET  := $(shell tput -Txterm sgr0)
+
+RANDTAG := $(shell head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13 ; echo '')
+
+#.PHONY: help build prepare flu-web-run flu-mob-run clean
+
+## Show help
+help:
+	@echo 'Server for mod-main'
+	@echo ''
+	@echo 'Usage:'
+	@echo '  ${YELLOW}make${RESET} ${GREEN}<target>${RESET}'
+	@echo ''
+	@echo 'Targets:'
+	@awk '/^[a-zA-Z\-\_0-9]+:/ { \
+		helpMessage = match(lastLine, /^## (.*)/); \
+		if (helpMessage) { \
+			helpCommand = substr($$1, 0, index($$1, ":")); \
+			helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
+			printf "  ${YELLOW}%-$(TARGET_MAX_CHAR_NUM)s${RESET} ${GREEN}%s${RESET}\n", helpCommand, helpMessage; \
+		} \
+	} \
+	{ lastLine = $$0 }' $(MAKEFILE_LIST)
+
+## Pull down gsheets data
+get-data:
+	@echo ''
+	@echo '$(YELLOW)IF THE CONFIGS CANNOT BE FOUND, MAKE SURE TO RUN $(WHITE)make build$(YELLOW) IN THE $(WHITE)boostrap/tools/i18n$(YELLOW) [github.com/getcouragenow/bootstrap]'
+	@echo ''
+	@echo 'If there are many 403 errors you may have ran into the google api limiter, check the output folder before assuming nothing made it through$(RESET)'
+	@echo ''
+	@mkdir -p ./data/config
+	@echo "*" > ./data/.gitignore
+	@cp ${GOPATH}/config/i18n/datadumpconfig.yml ./data/config/datadumpconfig.yml
+	@cd data && ${GOPATH}/bin/i18n gsheet -o datadump
+
+## Removes data folder and all of it's contents
+del-data:
+	@if [ -f ./data ]; then rm -r ./data; fi
+	@echo '${GREEN}Data Removed${RESET}'
+	@echo 'Run ${YELLOW}make get-data${RESET} to regenerate the data'
+
+go-srv:
+	cd cmd && go run server.go
+
+go-cli:
+	cd cmd && go run client.go

--- a/mod-main/server/cmd/client.go
+++ b/mod-main/server/cmd/client.go
@@ -6,6 +6,9 @@ import (
 	"flag"
 	pb "github.com/getcouragenow/packages/mod-main/server/pkg/api"
 	"time"
+	"os"
+	"path/filepath"
+	"fmt"
 
 	// pb "github.com/getcouragenow/packages/mod-main/server/pkg/api"
 	"github.com/johnsiilver/getcert"
@@ -21,6 +24,8 @@ var (
 )
 
 func main() {
+	printTestDataFiles()
+
 	flag.Parse()
 	err := godotenv.Load(*envFile)
 	if err != nil {
@@ -61,4 +66,20 @@ func main() {
 	}
 	
 	log.Printf("Got: %v", ans)
+}
+
+func printTestDataFiles() {
+	var files []string
+
+    root := "../data/outputs/datadump/"
+    err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+        files = append(files, path)
+        return nil
+    })
+    if err != nil {
+        panic(err)
+    }
+    for _, file := range files {
+        fmt.Println(file)
+    }
 }

--- a/mod-main/server/cmd/client.go
+++ b/mod-main/server/cmd/client.go
@@ -15,6 +15,7 @@ import (
 	"log"
 )
 
+// TODO extend for env vars needed
 var (
 	envFile = flag.String("c", "./env.sample", "path to config file")
 )

--- a/mod-main/server/cmd/server.go
+++ b/mod-main/server/cmd/server.go
@@ -11,7 +11,7 @@ import (
 	"os/signal"
 	"syscall"
 )
-
+// TODO need environment vars 
 func main() {
 	logger := glog.NewLoggerV2(os.Stdout, os.Stdout, os.Stdout)
 

--- a/mod-main/server/pkg/service/svc.go
+++ b/mod-main/server/pkg/service/svc.go
@@ -23,6 +23,7 @@ type Server struct {
 	logger glog.LoggerV2
 }
 
+// TODO client shouldnt' know anything about minio or buckets
 // New creates new instance of Svc,
 func New(ctx context.Context, bucketName string, logger glog.LoggerV2) (*Server, error) {
 	cfg, err := config.NewCfg()


### PR DESCRIPTION
This Issue: #368 relies on the following pull request: https://github.com/getcouragenow/bootstrap/pull/57

Essentially, when the the `bootstrap/tools/i18n` make file is run `make build` it will build the i18n executable AND transfer it's config values to the GOPATH location (this way they are usable outside of just mod-main.

When mod-main is run `make get-data` the configs are brought over from the GOPATH folder and the data is extracted.

`make del-data` allows us to remove the data locally if we need to as well