### PR TITLE
#545 master detail for /orgs with images

### DIFF
--- a/mod-main/client/lib/core/routes/paths.dart
+++ b/mod-main/client/lib/core/routes/paths.dart
@@ -4,18 +4,20 @@ class Paths{
   final String baseRoute;
   String userInfo;
   String orgs;
+  String orgsId;
   String ready;
   String supportRoles;
   String myNeeds;
   String splash;
   String dashboard;
-  String org;
+  String dashboardId;
 
   Paths(this.baseRoute) : 
    dashboard  = '$baseRoute/dashboard/orgs', // Admin dashboard routes
-   org = '$baseRoute/dashboard/orgs/:id', // Admin dashboard routes
+   dashboardId = '$baseRoute/dashboard/orgs/:id', // Admin dashboard routes
    userInfo = '$baseRoute/userInfo',// Non-Admin routes
    orgs = '$baseRoute/orgs',
+   orgsId = '$baseRoute/orgs/:id',
    ready = '$baseRoute/ready',
    supportRoles = '$baseRoute/supportRoles/orgs/:id',
    myNeeds = '$baseRoute/myneeds/orgs/:id',

--- a/mod-main/client/lib/modules/main_module.dart
+++ b/mod-main/client/lib/modules/main_module.dart
@@ -51,7 +51,8 @@ class MainAppModule extends ChildModule{
     Router("/", child: (_, args) => SplashView()),
     /// Non-Admin Dashboard Routes
     Router("/userInfo", child: (_, args) => UserInfoView()),
-    Router("/orgs", child: (_, args) => OrgView()),
+    Router("/orgs", child: (_, args) => OrgView(),),
+    Router("/orgs/:id", child: (_, args) => OrgView(id: int.tryParse(args.params['id']) ?? -1,)),
     Router("/myneeds/orgs/:id", child: (_, args) => UserNeedsView(orgID: args.params['id'],)),
     Router("/supportRoles/orgs/:id", child: (_, args) => SupportRoleView(orgId: args.params['id'],)),
     /// Admin Dashboard Routes

--- a/mod-main/client/lib/modules/org_manager/orgs/views/org_master_detail_view.dart
+++ b/mod-main/client/lib/modules/org_manager/orgs/views/org_master_detail_view.dart
@@ -24,7 +24,7 @@ class OrgMasterDetailView extends StatelessWidget {
   Widget build(BuildContext context) {
     return GetCourageMasterDetail<String>(
       id: id,
-      routeWithIdPlaceholder: Modular.get<Paths>().org,
+      routeWithIdPlaceholder: Modular.get<Paths>().dashboardId,
       detailsBuilder: _getDetailsView,
       labelBuilder: (item) => item,
       items: orgs,
@@ -32,17 +32,16 @@ class OrgMasterDetailView extends StatelessWidget {
     );
   }
 
-  Widget _getDetailsView(BuildContext context, int detailsId) {
+  Widget _getDetailsView(
+      BuildContext context, int detailsId, bool isFullScreen) {
     return ViewModelProvider.withConsumer(
       viewModel: OrgsViewModel(),
       builder: (context, OrgsViewModel model, child) => ResponsiveBuilder(
         builder: (context, sizingInfo) {
           return Scaffold(
             appBar: AppBar(
-              elevation: 0,
               // iconTheme: Theme.of(context).iconTheme,
-              automaticallyImplyLeading:
-                  (sizingInfo.screenSize.width > 1100) ? false : true,
+              automaticallyImplyLeading: isFullScreen,
               title: Text(orgs[detailsId]),
               // this the mock data
               actions: <Widget>[
@@ -51,13 +50,13 @@ class OrgMasterDetailView extends StatelessWidget {
                     icon: Icon(Icons.link),
                     onPressed: () async {
                       String link =
-                          "${Modular.get<EnvConfig>().url}/${Modular.get<Paths>().org.replaceFirst("/", "").replaceAll(":id", "${detailsId}")}";
+                          "${Modular.get<EnvConfig>().url}/${Modular.get<Paths>().dashboardId.replaceFirst("/", "").replaceAll(":id", "${detailsId}")}";
                       // ${Modular.get<Paths>().org.replaceAll(":id", "$index")
                       print(Modular.get<Paths>().baseRoute);
                       await Clipboard.setData(new ClipboardData(text: link));
                       print(link);
                       print(Modular.get<Paths>()
-                          .org
+                          .dashboardId
                           .replaceFirst("/", "")
                           .replaceAll(":id", "1"));
                     })

--- a/mod-main/client/lib/modules/orgs/views/org_detail_view.dart
+++ b/mod-main/client/lib/modules/orgs/views/org_detail_view.dart
@@ -6,163 +6,183 @@ import '../../../core/core.dart';
 
 class OrgDetailView extends StatelessWidget {
   final Org org;
+  final bool showBackButton;
 
-  const OrgDetailView({Key key, this.org}) : super(key: key);
+  const OrgDetailView({Key key, this.org, this.showBackButton = true})
+      : super(key: key);
+
   @override
   Widget build(BuildContext context) {
-    return ListView(
-      shrinkWrap: true,
-      children: <Widget>[
-        //   CarouselWithIndicator(imgList: campaign.videoURL),
-        ListTile(
-          title: Text(
-            ModMainLocalizations.of(context).translate('campaignName'),
-            style: Theme.of(context).textTheme.title,
-          ),
-          subtitle: Text(org.campaignName),
-        ),
-        const SizedBox(height: 16.0),
-        ListTile(
-          title: Text(
-            ModMainLocalizations.of(context).translate('category'),
-            style: Theme.of(context).textTheme.title,
-          ),
-          subtitle: Text(org.category),
-        ),
-        const SizedBox(height: 16.0),
-        ListTile(
-          title: Text(
-            ModMainLocalizations.of(context).translate('actionType'),
-            style: Theme.of(context).textTheme.title,
-          ),
-          subtitle: Text(org.actionType),
-        ),
-        const SizedBox(height: 16.0),
-        ListTile(
-          title: Text(
-            ModMainLocalizations.of(context).translate('actionLocation') + ' / ' + ModMainLocalizations.of(context).translate('time'),
-            style: Theme.of(context).textTheme.title,
-          ),
-          subtitle: Text(
-              '${org.actionLocation} / ${DateFormat('yyyy MMM dd HH:MM').format(org.actionTime)}'),
-        ),
-        const SizedBox(height: 16.0),
-        ListTile(
-          title: Text(
-            ModMainLocalizations.of(context).translate('lengthOfTheAction'),
-            style: Theme.of(context).textTheme.title,
-          ),
-          subtitle: Text('${org.actionLength} ${org.uom}'),
-        ),
-        const SizedBox(height: 16.0),
-        ListTile(
-          title: Text(
-            ModMainLocalizations.of(context).translate('goal'),
-            style: Theme.of(context).textTheme.title,
-          ),
-          subtitle: Text(org.goal),
-        ),
-        const SizedBox(height: 16.0),
-        ListTile(
-          title: Text(
-            ModMainLocalizations.of(context).translate('strategy'),
-            style: Theme.of(context).textTheme.title,
-          ),
-          subtitle: Text(org.strategy),
-        ),
-        const SizedBox(height: 16.0),
-        ListTile(
-          title: Text(
-          ModMainLocalizations.of(context).translate('historicalPrecedents'),
-            style: Theme.of(context).textTheme.title,
-          ),
-          subtitle: Text(org.histPrecedents),
-        ),
-        const SizedBox(height: 16.0),
-        ListTile(
-          title: Text(
-            ModMainLocalizations.of(context).translate('backingEndorsingOrganizations'),
-            style: Theme.of(context).textTheme.title,
-          ),
-          subtitle: Text(org.backingOrg.join('\n')),
-        ),
-        const SizedBox(height: 16.0),
-        ListTile(
-          title: Text(
-            ModMainLocalizations.of(context).translate('peopleAlreadyPledged'),
-            style: Theme.of(context).textTheme.title,
-          ),
-          subtitle: Text(org.alreadyPledged.toString()),
-        ),
-        const SizedBox(height: 16.0),
-        Card(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8.0),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.start,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: <Widget>[
-                ListTile(
-                  title: Text(
-                    ModMainLocalizations.of(context).translate('weNeed') + ' :',
-                    style: Theme.of(context).textTheme.title,
-                  ),
-                  subtitle: Text(
-                    ModMainLocalizations.of(context).translate('extrapolatedSimilarPastActions'),
-                    style: TextStyle(fontStyle: FontStyle.italic),
-                  ),
-                ),
-                ListTile(
-                  title: Text(ModMainLocalizations.of(context).translate('pioneersToStart')),
-                  trailing: Text(
-                    '${org.minPioneers}',
-                    style: TextStyle(color: Theme.of(context).accentColor),
-                  ),
-                ),
-                ListTile(
-                  title: Text(ModMainLocalizations.of(context).translate('rebelsMedia')),
-                  trailing: Text(
-                    '${org.minRebelsForMedia}',
-                    style: TextStyle(color: Theme.of(context).accentColor),
-                  ),
-                ),
-                ListTile(
-                  title: Text(ModMainLocalizations.of(context).translate('rebelsWin')),
-                  trailing: Text(
-                    '${org.minRebelsToWin}',
-                    style: TextStyle(color: Theme.of(context).accentColor),
-                  ),
-                ),
-              ],
+    return Scaffold(
+      appBar: AppBar(
+        automaticallyImplyLeading: showBackButton,
+        title:
+            Text(ModMainLocalizations.of(context).translate('campaignDetails')),
+      ),
+      body: ListView(
+        shrinkWrap: true,
+        children: <Widget>[
+          //   CarouselWithIndicator(imgList: campaign.videoURL),
+          ListTile(
+            title: Text(
+              ModMainLocalizations.of(context).translate('campaignName'),
+              style: Theme.of(context).textTheme.title,
             ),
+            subtitle: Text(org.campaignName),
           ),
-        ),
-        const SizedBox(height: 16.0),
-        ListTile(
-          title: Text(
-        ModMainLocalizations.of(context).translate('contactDetails'),
-            style: Theme.of(context).textTheme.title,
+          const SizedBox(height: 16.0),
+          ListTile(
+            title: Text(
+              ModMainLocalizations.of(context).translate('category'),
+              style: Theme.of(context).textTheme.title,
+            ),
+            subtitle: Text(org.category),
           ),
-          subtitle: Text(org.contact),
-        ),
-        const SizedBox(height: 16.0),
-        ButtonBar(children: [
-          FlatButton(
-            onPressed: () {
-              Modular.to.pushNamed(
-                  Modular.get<Paths>().myNeeds.replaceAll(':id', org.id));
-            },
-            child: Text(ModMainLocalizations.of(context).translate("notReady")),
+          const SizedBox(height: 16.0),
+          ListTile(
+            title: Text(
+              ModMainLocalizations.of(context).translate('actionType'),
+              style: Theme.of(context).textTheme.title,
+            ),
+            subtitle: Text(org.actionType),
           ),
-          RaisedButton(
-            onPressed: () {
-              Modular.to.pushNamed('/account/signup');
-            },
-            child: Text(ModMainLocalizations.of(context).translate("ready")),
+          const SizedBox(height: 16.0),
+          ListTile(
+            title: Text(
+              ModMainLocalizations.of(context).translate('actionLocation') +
+                  ' / ' +
+                  ModMainLocalizations.of(context).translate('time'),
+              style: Theme.of(context).textTheme.title,
+            ),
+            subtitle: Text(
+                '${org.actionLocation} / ${DateFormat('yyyy MMM dd HH:MM').format(org.actionTime)}'),
           ),
-        ]),
-        const SizedBox(height: 8.0),
-      ],
+          const SizedBox(height: 16.0),
+          ListTile(
+            title: Text(
+              ModMainLocalizations.of(context).translate('lengthOfTheAction'),
+              style: Theme.of(context).textTheme.title,
+            ),
+            subtitle: Text('${org.actionLength} ${org.uom}'),
+          ),
+          const SizedBox(height: 16.0),
+          ListTile(
+            title: Text(
+              ModMainLocalizations.of(context).translate('goal'),
+              style: Theme.of(context).textTheme.title,
+            ),
+            subtitle: Text(org.goal),
+          ),
+          const SizedBox(height: 16.0),
+          ListTile(
+            title: Text(
+              ModMainLocalizations.of(context).translate('strategy'),
+              style: Theme.of(context).textTheme.title,
+            ),
+            subtitle: Text(org.strategy),
+          ),
+          const SizedBox(height: 16.0),
+          ListTile(
+            title: Text(
+              ModMainLocalizations.of(context)
+                  .translate('historicalPrecedents'),
+              style: Theme.of(context).textTheme.title,
+            ),
+            subtitle: Text(org.histPrecedents),
+          ),
+          const SizedBox(height: 16.0),
+          ListTile(
+            title: Text(
+              ModMainLocalizations.of(context)
+                  .translate('backingEndorsingOrganizations'),
+              style: Theme.of(context).textTheme.title,
+            ),
+            subtitle: Text(org.backingOrg.join('\n')),
+          ),
+          const SizedBox(height: 16.0),
+          ListTile(
+            title: Text(
+              ModMainLocalizations.of(context)
+                  .translate('peopleAlreadyPledged'),
+              style: Theme.of(context).textTheme.title,
+            ),
+            subtitle: Text(org.alreadyPledged.toString()),
+          ),
+          const SizedBox(height: 16.0),
+          Card(
+            child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8.0),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: <Widget>[
+                    ListTile(
+                      title: Text(
+                        ModMainLocalizations.of(context).translate('weNeed') +
+                            ' :',
+                        style: Theme.of(context).textTheme.title,
+                      ),
+                      subtitle: Text(
+                        ModMainLocalizations.of(context)
+                            .translate('extrapolatedSimilarPastActions'),
+                        style: TextStyle(fontStyle: FontStyle.italic),
+                      ),
+                    ),
+                    ListTile(
+                      title: Text(ModMainLocalizations.of(context)
+                          .translate('pioneersToStart')),
+                      trailing: Text(
+                        '${org.minPioneers}',
+                        style: TextStyle(color: Theme.of(context).accentColor),
+                      ),
+                    ),
+                    ListTile(
+                      title: Text(ModMainLocalizations.of(context)
+                          .translate('rebelsMedia')),
+                      trailing: Text(
+                        '${org.minRebelsForMedia}',
+                        style: TextStyle(color: Theme.of(context).accentColor),
+                      ),
+                    ),
+                    ListTile(
+                      title: Text(ModMainLocalizations.of(context)
+                          .translate('rebelsWin')),
+                      trailing: Text(
+                        '${org.minRebelsToWin}',
+                        style: TextStyle(color: Theme.of(context).accentColor),
+                      ),
+                    ),
+                  ],
+                )),
+          ),
+          const SizedBox(height: 16.0),
+          ListTile(
+            title: Text(
+              ModMainLocalizations.of(context).translate('contactDetails'),
+              style: Theme.of(context).textTheme.title,
+            ),
+            subtitle: Text(org.contact),
+          ),
+          const SizedBox(height: 16.0),
+          ButtonBar(children: [
+            FlatButton(
+              onPressed: () {
+                Modular.to.pushNamed(
+                    Modular.get<Paths>().myNeeds.replaceAll(':id', org.id));
+              },
+              child:
+                  Text(ModMainLocalizations.of(context).translate("notReady")),
+            ),
+            RaisedButton(
+              onPressed: () {
+                Modular.to.pushNamed('/account/signup');
+              },
+              child: Text(ModMainLocalizations.of(context).translate("ready")),
+            ),
+          ]),
+          const SizedBox(height: 8.0),
+        ],
+      ),
     );
   }
 }

--- a/mod-main/client/lib/modules/orgs/views/org_detail_view.dart
+++ b/mod-main/client/lib/modules/orgs/views/org_detail_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:intl/intl.dart';
 import 'package:mod_main/modules/orgs/data/org_model.dart';
+import 'package:mod_main/modules/widgets/campaign_header.dart';
 import '../../../core/core.dart';
 
 class OrgDetailView extends StatelessWidget {
@@ -19,168 +20,186 @@ class OrgDetailView extends StatelessWidget {
         title:
             Text(ModMainLocalizations.of(context).translate('campaignDetails')),
       ),
-      body: ListView(
-        shrinkWrap: true,
+      body: Column(
         children: <Widget>[
-          //   CarouselWithIndicator(imgList: campaign.videoURL),
-          ListTile(
-            title: Text(
-              ModMainLocalizations.of(context).translate('campaignName'),
-              style: Theme.of(context).textTheme.title,
-            ),
-            subtitle: Text(org.campaignName),
+          CampaignHeader(
+            org: org,
           ),
-          const SizedBox(height: 16.0),
-          ListTile(
-            title: Text(
-              ModMainLocalizations.of(context).translate('category'),
-              style: Theme.of(context).textTheme.title,
+          Expanded(
+            child: ListView(
+              shrinkWrap: true,
+              children: <Widget>[
+                //   CarouselWithIndicator(imgList: campaign.videoURL),
+                ListTile(
+                  title: Text(
+                    ModMainLocalizations.of(context).translate('campaignName'),
+                    style: Theme.of(context).textTheme.title,
+                  ),
+                  subtitle: Text(org.campaignName),
+                ),
+                const SizedBox(height: 16.0),
+                ListTile(
+                  title: Text(
+                    ModMainLocalizations.of(context).translate('category'),
+                    style: Theme.of(context).textTheme.title,
+                  ),
+                  subtitle: Text(org.category),
+                ),
+                const SizedBox(height: 16.0),
+                ListTile(
+                  title: Text(
+                    ModMainLocalizations.of(context).translate('actionType'),
+                    style: Theme.of(context).textTheme.title,
+                  ),
+                  subtitle: Text(org.actionType),
+                ),
+                const SizedBox(height: 16.0),
+                ListTile(
+                  title: Text(
+                    ModMainLocalizations.of(context)
+                            .translate('actionLocation') +
+                        ' / ' +
+                        ModMainLocalizations.of(context).translate('time'),
+                    style: Theme.of(context).textTheme.title,
+                  ),
+                  subtitle: Text(
+                      '${org.actionLocation} / ${DateFormat('yyyy MMM dd HH:MM').format(org.actionTime)}'),
+                ),
+                const SizedBox(height: 16.0),
+                ListTile(
+                  title: Text(
+                    ModMainLocalizations.of(context)
+                        .translate('lengthOfTheAction'),
+                    style: Theme.of(context).textTheme.title,
+                  ),
+                  subtitle: Text('${org.actionLength} ${org.uom}'),
+                ),
+                const SizedBox(height: 16.0),
+                ListTile(
+                  title: Text(
+                    ModMainLocalizations.of(context).translate('goal'),
+                    style: Theme.of(context).textTheme.title,
+                  ),
+                  subtitle: Text(org.goal),
+                ),
+                const SizedBox(height: 16.0),
+                ListTile(
+                  title: Text(
+                    ModMainLocalizations.of(context).translate('strategy'),
+                    style: Theme.of(context).textTheme.title,
+                  ),
+                  subtitle: Text(org.strategy),
+                ),
+                const SizedBox(height: 16.0),
+                ListTile(
+                  title: Text(
+                    ModMainLocalizations.of(context)
+                        .translate('historicalPrecedents'),
+                    style: Theme.of(context).textTheme.title,
+                  ),
+                  subtitle: Text(org.histPrecedents),
+                ),
+                const SizedBox(height: 16.0),
+                ListTile(
+                  title: Text(
+                    ModMainLocalizations.of(context)
+                        .translate('backingEndorsingOrganizations'),
+                    style: Theme.of(context).textTheme.title,
+                  ),
+                  subtitle: Text(org.backingOrg.join('\n')),
+                ),
+                const SizedBox(height: 16.0),
+                ListTile(
+                  title: Text(
+                    ModMainLocalizations.of(context)
+                        .translate('peopleAlreadyPledged'),
+                    style: Theme.of(context).textTheme.title,
+                  ),
+                  subtitle: Text(org.alreadyPledged.toString()),
+                ),
+                const SizedBox(height: 16.0),
+                Card(
+                  child: Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 8.0),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: <Widget>[
+                          ListTile(
+                            title: Text(
+                              ModMainLocalizations.of(context)
+                                      .translate('weNeed') +
+                                  ' :',
+                              style: Theme.of(context).textTheme.title,
+                            ),
+                            subtitle: Text(
+                              ModMainLocalizations.of(context)
+                                  .translate('extrapolatedSimilarPastActions'),
+                              style: TextStyle(fontStyle: FontStyle.italic),
+                            ),
+                          ),
+                          ListTile(
+                            title: Text(ModMainLocalizations.of(context)
+                                .translate('pioneersToStart')),
+                            trailing: Text(
+                              '${org.minPioneers}',
+                              style: TextStyle(
+                                  color: Theme.of(context).accentColor),
+                            ),
+                          ),
+                          ListTile(
+                            title: Text(ModMainLocalizations.of(context)
+                                .translate('rebelsMedia')),
+                            trailing: Text(
+                              '${org.minRebelsForMedia}',
+                              style: TextStyle(
+                                  color: Theme.of(context).accentColor),
+                            ),
+                          ),
+                          ListTile(
+                            title: Text(ModMainLocalizations.of(context)
+                                .translate('rebelsWin')),
+                            trailing: Text(
+                              '${org.minRebelsToWin}',
+                              style: TextStyle(
+                                  color: Theme.of(context).accentColor),
+                            ),
+                          ),
+                        ],
+                      )),
+                ),
+                const SizedBox(height: 16.0),
+                ListTile(
+                  title: Text(
+                    ModMainLocalizations.of(context)
+                        .translate('contactDetails'),
+                    style: Theme.of(context).textTheme.title,
+                  ),
+                  subtitle: Text(org.contact),
+                ),
+                const SizedBox(height: 16.0),
+                ButtonBar(children: [
+                  FlatButton(
+                    onPressed: () {
+                      Modular.to.pushNamed(Modular.get<Paths>()
+                          .myNeeds
+                          .replaceAll(':id', org.id));
+                    },
+                    child: Text(
+                        ModMainLocalizations.of(context).translate("notReady")),
+                  ),
+                  RaisedButton(
+                    onPressed: () {
+                      Modular.to.pushNamed('/account/signup');
+                    },
+                    child: Text(
+                        ModMainLocalizations.of(context).translate("ready")),
+                  ),
+                ]),
+                const SizedBox(height: 8.0),
+              ],
             ),
-            subtitle: Text(org.category),
           ),
-          const SizedBox(height: 16.0),
-          ListTile(
-            title: Text(
-              ModMainLocalizations.of(context).translate('actionType'),
-              style: Theme.of(context).textTheme.title,
-            ),
-            subtitle: Text(org.actionType),
-          ),
-          const SizedBox(height: 16.0),
-          ListTile(
-            title: Text(
-              ModMainLocalizations.of(context).translate('actionLocation') +
-                  ' / ' +
-                  ModMainLocalizations.of(context).translate('time'),
-              style: Theme.of(context).textTheme.title,
-            ),
-            subtitle: Text(
-                '${org.actionLocation} / ${DateFormat('yyyy MMM dd HH:MM').format(org.actionTime)}'),
-          ),
-          const SizedBox(height: 16.0),
-          ListTile(
-            title: Text(
-              ModMainLocalizations.of(context).translate('lengthOfTheAction'),
-              style: Theme.of(context).textTheme.title,
-            ),
-            subtitle: Text('${org.actionLength} ${org.uom}'),
-          ),
-          const SizedBox(height: 16.0),
-          ListTile(
-            title: Text(
-              ModMainLocalizations.of(context).translate('goal'),
-              style: Theme.of(context).textTheme.title,
-            ),
-            subtitle: Text(org.goal),
-          ),
-          const SizedBox(height: 16.0),
-          ListTile(
-            title: Text(
-              ModMainLocalizations.of(context).translate('strategy'),
-              style: Theme.of(context).textTheme.title,
-            ),
-            subtitle: Text(org.strategy),
-          ),
-          const SizedBox(height: 16.0),
-          ListTile(
-            title: Text(
-              ModMainLocalizations.of(context)
-                  .translate('historicalPrecedents'),
-              style: Theme.of(context).textTheme.title,
-            ),
-            subtitle: Text(org.histPrecedents),
-          ),
-          const SizedBox(height: 16.0),
-          ListTile(
-            title: Text(
-              ModMainLocalizations.of(context)
-                  .translate('backingEndorsingOrganizations'),
-              style: Theme.of(context).textTheme.title,
-            ),
-            subtitle: Text(org.backingOrg.join('\n')),
-          ),
-          const SizedBox(height: 16.0),
-          ListTile(
-            title: Text(
-              ModMainLocalizations.of(context)
-                  .translate('peopleAlreadyPledged'),
-              style: Theme.of(context).textTheme.title,
-            ),
-            subtitle: Text(org.alreadyPledged.toString()),
-          ),
-          const SizedBox(height: 16.0),
-          Card(
-            child: Padding(
-                padding: const EdgeInsets.symmetric(vertical: 8.0),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: <Widget>[
-                    ListTile(
-                      title: Text(
-                        ModMainLocalizations.of(context).translate('weNeed') +
-                            ' :',
-                        style: Theme.of(context).textTheme.title,
-                      ),
-                      subtitle: Text(
-                        ModMainLocalizations.of(context)
-                            .translate('extrapolatedSimilarPastActions'),
-                        style: TextStyle(fontStyle: FontStyle.italic),
-                      ),
-                    ),
-                    ListTile(
-                      title: Text(ModMainLocalizations.of(context)
-                          .translate('pioneersToStart')),
-                      trailing: Text(
-                        '${org.minPioneers}',
-                        style: TextStyle(color: Theme.of(context).accentColor),
-                      ),
-                    ),
-                    ListTile(
-                      title: Text(ModMainLocalizations.of(context)
-                          .translate('rebelsMedia')),
-                      trailing: Text(
-                        '${org.minRebelsForMedia}',
-                        style: TextStyle(color: Theme.of(context).accentColor),
-                      ),
-                    ),
-                    ListTile(
-                      title: Text(ModMainLocalizations.of(context)
-                          .translate('rebelsWin')),
-                      trailing: Text(
-                        '${org.minRebelsToWin}',
-                        style: TextStyle(color: Theme.of(context).accentColor),
-                      ),
-                    ),
-                  ],
-                )),
-          ),
-          const SizedBox(height: 16.0),
-          ListTile(
-            title: Text(
-              ModMainLocalizations.of(context).translate('contactDetails'),
-              style: Theme.of(context).textTheme.title,
-            ),
-            subtitle: Text(org.contact),
-          ),
-          const SizedBox(height: 16.0),
-          ButtonBar(children: [
-            FlatButton(
-              onPressed: () {
-                Modular.to.pushNamed(
-                    Modular.get<Paths>().myNeeds.replaceAll(':id', org.id));
-              },
-              child:
-                  Text(ModMainLocalizations.of(context).translate("notReady")),
-            ),
-            RaisedButton(
-              onPressed: () {
-                Modular.to.pushNamed('/account/signup');
-              },
-              child: Text(ModMainLocalizations.of(context).translate("ready")),
-            ),
-          ]),
-          const SizedBox(height: 8.0),
         ],
       ),
     );

--- a/mod-main/client/lib/modules/orgs/views/org_view.dart
+++ b/mod-main/client/lib/modules/orgs/views/org_view.dart
@@ -1,66 +1,47 @@
 import 'package:floating_search_bar/ui/sliver_search_bar.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:mod_main/modules/orgs/data/org_model.dart';
 import 'package:mod_main/modules/orgs/view_model/org_view_model.dart';
 import 'package:provider_architecture/provider_architecture.dart';
 import 'package:responsive_scaffold/responsive_scaffold.dart';
 import 'package:mod_main/core/core.dart';
+import 'package:sys_core/sys_core.dart';
 
 import 'org_detail_view.dart';
 
 class OrgView extends StatelessWidget {
-  var _scaffoldKey = new GlobalKey<ScaffoldState>();
+  final int id;
+
+  const OrgView({Key key, this.id = -1}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return ViewModelProvider.withConsumer(
       viewModel: OrgViewModel(),
-      builder: (context, OrgViewModel model, child) {
-        return Scaffold(
-          appBar: AppBar(title: Text(ModMainLocalizations.of(context).translate('selectCampaign')),),
-          body: ResponsiveListScaffold.builder(
-            scaffoldKey: _scaffoldKey,
-            detailBuilder: (context, int index, tablet) {
-              return DetailsScreen(
-                body: Scaffold(
-                    appBar: AppBar(
-                      elevation: 0.0,
-                      centerTitle: true,
-                      title: Text(ModMainLocalizations.of(context).translate('campaignDetails')),
-                      automaticallyImplyLeading: !tablet,
-                    ),
-                    body: OrgDetailView(org: model.orgs[index])),
-              );
-            },
-            nullItems: Center(child: CircularProgressIndicator()),
-            emptyItems: Center(child: Text(ModMainLocalizations.of(context).translate('noCampaigns'))),
-            itemCount: model.orgs.length,
-            slivers: <Widget>[
-              SliverPadding(
-                padding: EdgeInsets.symmetric(vertical: 8.0),
-                sliver: SliverFloatingBar(
-                  elevation: 1.0,
-                  floating: true,
-                  pinned: true,
-                  automaticallyImplyLeading: false,
-                  title: TextField(
-                    decoration:
-                        InputDecoration.collapsed(hintText: ModMainLocalizations.of(context).translate('searchCampaigns')),
+      builder: (context, OrgViewModel model, child) =>
+          Scaffold(
+            body: GetCourageMasterDetail<Org>(
+                id: id,
+                items: model.orgs,
+                labelBuilder: (item) => item.campaignName,
+                imageBuilder: (item) => item.logoUrl,
+                routeWithIdPlaceholder: Modular
+                    .get<Paths>()
+                    .orgsId,
+                detailsBuilder: (context, detailsId, isFullScreen) =>
+                    OrgDetailView(org: model.orgs[detailsId], showBackButton:isFullScreen),
+                noItemsAvailable: Center(
+                  child: Text(
+                    ModMainLocalizations.of(context).translate('noCampaigns'),
                   ),
                 ),
-              ),
-            
-            ],
-            itemBuilder: (BuildContext context, int index) {
-              return ListTile(
-                leading: CircleAvatar(
-                  radius: 20,
-                  backgroundImage: NetworkImage(model.orgs[index].logoUrl),
-                ),
-                title: Text(model.orgs[index].campaignName),
-              );
-            },
+                disableBackButtonOnNoItemSelected: false,
+                masterAppBarTitle: Text(
+                    ModMainLocalizations.of(context).translate(
+                        'selectCampaign')),
+            ),
           ),
-        );
-      },
     );
   }
 }

--- a/mod-main/client/lib/modules/support_roles/views/support_role_view.dart
+++ b/mod-main/client/lib/modules/support_roles/views/support_role_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:mod_main/modules/widgets/campaign_header.dart';
 import 'package:provider_architecture/provider_architecture.dart';
 import 'package:mod_main/modules/support_roles/data/support_role_model.dart';
 import 'package:mod_main/core/shared_services/dynamic_widget_service.dart';
@@ -19,43 +20,23 @@ class SupportRoleView extends StatelessWidget {
         model.fetchOrgById(orgId);
       },
       viewModel: SupportRoleViewModel(),
-      builder: (context, SupportRoleViewModel model, child) =>
-          Scaffold(
-            appBar: AppBar(
-              title:
+      builder: (context, SupportRoleViewModel model, child) => Scaffold(
+        appBar: AppBar(
+          title:
               Text(ModMainLocalizations.of(context).translate('supportRoles')),
-              centerTitle: true,
-            ),
-            body: (model.buzy)
-                ? Center(child: Offstage())
-                : Column(children: [
-              Card(
-                child: Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: ListTile(
-                    leading: CircleAvatar(
-                      backgroundImage: NetworkImage(model.org.logoUrl),
-                    ),
-                    title: Text(
-                      model.org.campaignName,
-                      style: Theme
-                          .of(context)
-                          .textTheme
-                          .title,
-                    ),
-                    subtitle: Text(
-                      model.org.goal,
-                      maxLines: 3,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
+          centerTitle: true,
+        ),
+        body: (model.buzy)
+            ? Center(child: Offstage())
+            : Column(children: [
+                CampaignHeader(
+                  org: model.org,
                 ),
-              ),
-              Expanded(
-                child: _buildSupportRolesList(context, model),
-              ),
-            ]),
-          ),
+                Expanded(
+                  child: _buildSupportRolesList(context, model),
+                ),
+              ]),
+      ),
     );
   }
 

--- a/mod-main/client/lib/modules/widgets/campaign_header.dart
+++ b/mod-main/client/lib/modules/widgets/campaign_header.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:mod_main/modules/orgs/data/org_model.dart';
+
+class CampaignHeader extends StatelessWidget {
+  final Org org;
+
+  const CampaignHeader({Key key, @required this.org})
+      : assert(org != null),
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: ListTile(
+          leading: CircleAvatar(
+            backgroundImage: NetworkImage(org.logoUrl),
+          ),
+          title: Text(
+            org.campaignName,
+            style: Theme.of(context).textTheme.title,
+          ),
+          subtitle: Text(
+            org.goal,
+            maxLines: 3,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mod-write/client/lib/view/list_document.dart
+++ b/mod-write/client/lib/view/list_document.dart
@@ -25,7 +25,7 @@ class _DocumentListState extends State<DocumentList> {
       routeWithIdPlaceholder: Modular
           .get<Paths>()
           .detail,
-      detailsBuilder: (context, detailsId) =>
+      detailsBuilder: (context, detailsId, isFullScreen) =>
           FullPageEditorScreen(key: ValueKey(detailsId),
               id: detailsId),
       items: _listDocument,

--- a/mod-write/client/lib/view/src/full_page.dart
+++ b/mod-write/client/lib/view/src/full_page.dart
@@ -12,8 +12,11 @@ import 'package:mod_write/view/src/zefyr_image_delegate.dart'
 
 class FullPageEditorScreen extends StatefulWidget {
   final int id;
+  final bool showBackButton;
 
-  const FullPageEditorScreen({Key key, @required this.id}) : super(key: key);
+  const FullPageEditorScreen(
+      {Key key, @required this.id, this.showBackButton = false})
+      : super(key: key);
 
   @override
   _FullPageEditorScreenState createState() => _FullPageEditorScreenState();
@@ -45,8 +48,8 @@ class _FullPageEditorScreenState extends State<FullPageEditorScreen> {
   }
 
   Delta getDelta() {
-    return Delta.fromJson(json.decode(StubData.documents[widget.id]
-        .content) as List);
+    return Delta.fromJson(
+        json.decode(StubData.documents[widget.id].content) as List);
   }
 
   @override
@@ -62,6 +65,7 @@ class _FullPageEditorScreenState extends State<FullPageEditorScreen> {
         : IconButton(onPressed: _startEditing, icon: Icon(Icons.edit));
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: widget.showBackButton,
         actions: <Widget>[done],
       ),
       resizeToAvoidBottomPadding: true,


### PR DESCRIPTION
#545 Improved GetCourageMasterDetail class.

It now can handle item images and has a better AppBar functionality especially regarding the automatically added back button.

Added a CampaignHeader to /orgs detail view to be consistent with /supportRoles/ detail page