### PR TITLE
added bs.sh to allow boilerplates to be imported. 

### DIFF
--- a/bs.sh
+++ b/bs.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+
+# this is needed for bootstrapping this repo manually and then checking it in.
+# whenever our boilerplate change we have to do this.
+
+SOURCE_FSPATH="./../core-runtime/boilerplate"
+echo SOURCE_FSPATH: ${SOURCE_FSPATH}
+
+TARGET_FSPATH="${PWD}/boilerplate/"
+echo TARGET_FSPATH: ${TARGET_FSPATH}
+
+# clean it
+#rm -rf ${TARGET_FSPATH}
+
+# update it
+#cp -r ${SOURCE_FSPATH} ${TARGET_FSPATH}


### PR DESCRIPTION
Core CI is not done, so this is a work around

NOTE that this will pump into boilerplate/core.

All makefiles in packages would have to be updated to use it.
I DONT think we should start to USE bs.sh YET, because the .mk's need a little more refactoring.
