### PR TITLE
Fix example for mod-account.

### DIFF
--- a/mod-account/client/example/lib/main.dart
+++ b/mod-account/client/example/lib/main.dart
@@ -26,6 +26,7 @@ class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      navigatorKey: Modular.navigatorKey,
       debugShowCheckedModeBanner: false,
       initialRoute: "/",
       onGenerateRoute: Modular.generateRoute,


### PR DESCRIPTION
When using `Modular`, it must be add `navigatorKey: Modular.navigatorKey` in `MaterialApp`
```dart
    return MaterialApp(
      navigatorKey: Modular.navigatorKey,
      debugShowCheckedModeBanner: false,
      ...
```